### PR TITLE
fix(1): add frontend scaffold to resolve build failure

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "pomodoro-frontend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pomodoro-frontend",
+      "version": "0.1.0"
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pomodoro-frontend",
+  "version": "0.1.0",
+  "description": "React + Vite frontend for Pomodoro Timer (scaffold — full implementation pending)",
+  "scripts": {
+    "build": "node scripts/build.js",
+    "dev": "node scripts/dev.js"
+  },
+  "dependencies": {}
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pomodoro Timer</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #1a1a2e;
+      color: #e0e0e0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+    }
+    .container {
+      text-align: center;
+      padding: 2rem;
+    }
+    h1 { font-size: 2.5rem; margin-bottom: 0.5rem; color: #e94560; }
+    p  { color: #a0a0b0; font-size: 1.1rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>🍅 Pomodoro Timer</h1>
+    <p>Frontend coming soon&hellip;</p>
+    <p style="font-size:0.85rem;margin-top:2rem;opacity:0.5">
+      Backend API available at <code>http://localhost:3001/api/sessions</code>
+    </p>
+  </div>
+</body>
+</html>

--- a/frontend/scripts/build.js
+++ b/frontend/scripts/build.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+/**
+ * Minimal build script — copies public/index.html to dist/index.html.
+ * Will be replaced by Vite when the React frontend is implemented.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const distDir = path.join(root, 'dist');
+const src = path.join(root, 'public', 'index.html');
+const dest = path.join(distDir, 'index.html');
+
+fs.mkdirSync(distDir, { recursive: true });
+fs.copyFileSync(src, dest);
+
+process.stdout.write(`Build complete: ${dest}\n`);

--- a/frontend/scripts/dev.js
+++ b/frontend/scripts/dev.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+/**
+ * Dev server stub — will be replaced by Vite when React frontend is implemented.
+ */
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 5173;
+const publicDir = path.join(__dirname, '..', 'public');
+
+const server = http.createServer((req, res) => {
+  const file = path.join(publicDir, 'index.html');
+  res.writeHead(200, { 'Content-Type': 'text/html' });
+  fs.createReadStream(file).pipe(res);
+});
+
+server.listen(PORT, () => {
+  process.stdout.write(`Dev server running at http://localhost:${PORT}\n`);
+});


### PR DESCRIPTION
Fix for build failure after Feature 1 merge (Issue #1).

## Root Cause

The orchestrator `deploy_project()` function requires `frontend/package.json` with a `build` script that produces `frontend/dist/index.html`. After merging Feature 1 (backend only), no frontend scaffold existed, causing the deploy step to fail with "No servable content found".

## Fix

Added a minimal **zero-dependency** frontend scaffold:

| File | Purpose |
|---|---|
| `frontend/package.json` | `build` + `dev` scripts, no external deps |
| `frontend/scripts/build.js` | Copies `public/index.html` → `dist/index.html` |
| `frontend/scripts/dev.js` | Minimal HTTP server stub for local dev |
| `frontend/public/index.html` | Placeholder page |

## Verification

```
cd frontend && npm install && npm run build
# → Build complete: frontend/dist/index.html (exit 0)
```

## Notes

This scaffold will be **replaced** by the full React + Vite implementation in subsequent features. It exists only to satisfy the orchestrator build check while Feature 1 (backend) is the only merged feature.

---
*Created by Antigravity Dev Agent*