### PR TITLE
feat(3): Session History Panel and Backend Integration

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,15 +1,24 @@
 import { useState } from 'react'
 import { useTimer } from './hooks/useTimer'
+import { useSessions } from './hooks/useSessions'
 import ModeSelector from './components/ModeSelector'
 import TimerDisplay from './components/TimerDisplay'
 import TimerControls from './components/TimerControls'
+import SessionHistory from './components/SessionHistory'
 
 export default function App() {
   const [workMins, setWorkMins] = useState(25)
   const [breakMins, setBreakMins] = useState(5)
 
+  const { sessions, loading, saveSession } = useSessions()
+
   const { mode, running, timeLeft, total, start, pause, reset, switchMode } =
-    useTimer({ workMins, breakMins, onComplete: null })
+    useTimer({
+      workMins,
+      breakMins,
+      // Called when a session completes: persist to backend + refresh history
+      onComplete: (completedMode, duration) => saveSession(completedMode, duration),
+    })
 
   return (
     <div className="app">
@@ -38,6 +47,8 @@ export default function App() {
             onReset={reset}
           />
         </div>
+
+        <SessionHistory sessions={sessions} loading={loading} />
       </main>
     </div>
   )

--- a/frontend/src/components/SessionHistory.jsx
+++ b/frontend/src/components/SessionHistory.jsx
@@ -1,0 +1,53 @@
+function formatDuration(seconds) {
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  return s > 0 ? `${m}m ${s}s` : `${m}m`
+}
+
+function formatTimestamp(isoString) {
+  return new Date(isoString).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export default function SessionHistory({ sessions, loading }) {
+  const workCount = sessions.filter((s) => s.type === 'work').length
+
+  return (
+    <div className="session-history">
+      <div className="session-history__header">
+        <h2 className="session-history__title">Today&rsquo;s Sessions</h2>
+        <span className="session-history__count" aria-label={`${workCount} pomodoros completed`}>
+          🍅 {workCount} pomodoro{workCount !== 1 ? 's' : ''}
+        </span>
+      </div>
+
+      {loading ? (
+        <p className="session-history__empty">Loading…</p>
+      ) : sessions.length === 0 ? (
+        <p className="session-history__empty">
+          No sessions yet — start your first pomodoro!
+        </p>
+      ) : (
+        <ul className="session-list">
+          {sessions
+            .slice()
+            .reverse()
+            .map((s) => (
+              <li key={s.id} className="session-item">
+                <span className="session-item__icon">
+                  {s.type === 'work' ? '🍅' : '☕'}
+                </span>
+                <span className="session-item__label">
+                  {s.type === 'work' ? 'Work' : 'Break'}
+                </span>
+                <span className="session-item__duration">{formatDuration(s.duration)}</span>
+                <span className="session-item__time">{formatTimestamp(s.timestamp)}</span>
+              </li>
+            ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useSessions.js
+++ b/frontend/src/hooks/useSessions.js
@@ -1,0 +1,42 @@
+import { useState, useEffect, useCallback } from 'react'
+import { getSessions, postSession } from '../services/api'
+
+export function useSessions() {
+  const [sessions, setSessions] = useState([])
+  const [loading, setLoading] = useState(true)
+
+  const fetchSessions = useCallback(async () => {
+    try {
+      const data = await getSessions()
+      setSessions(data)
+    } catch (_) {
+      // Backend may not be running in static/preview mode; degrade gracefully
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  // Load sessions on mount
+  useEffect(() => {
+    fetchSessions()
+  }, [fetchSessions])
+
+  /**
+   * POST a completed session then refresh the list.
+   * @param {string} type  'work' | 'break'
+   * @param {number} duration  seconds
+   */
+  const saveSession = useCallback(
+    async (type, duration) => {
+      try {
+        await postSession({ type, duration, timestamp: new Date().toISOString() })
+        await fetchSessions()
+      } catch (_) {
+        // Backend unavailable — skip silently
+      }
+    },
+    [fetchSessions],
+  )
+
+  return { sessions, loading, saveSession }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -249,3 +249,94 @@ body {
 .btn--secondary:hover {
   color: var(--color-text);
 }
+
+/* ============================================================
+   Session History
+   ============================================================ */
+.session-history {
+  background-color: var(--color-surface);
+  border-radius: var(--radius);
+  padding: 1.25rem 1.5rem;
+  width: 100%;
+}
+
+.session-history__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.session-history__title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.session-history__count {
+  font-size: 0.85rem;
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.session-history__empty {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  text-align: center;
+  padding: 0.5rem 0;
+}
+
+.session-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.session-list::-webkit-scrollbar {
+  width: 4px;
+}
+
+.session-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.session-list::-webkit-scrollbar-thumb {
+  background: var(--color-track);
+  border-radius: 2px;
+}
+
+.session-item {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: var(--radius-sm);
+  background-color: var(--color-surface-2);
+  font-size: 0.85rem;
+}
+
+.session-item__icon {
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.session-item__label {
+  flex: 1;
+  color: var(--color-text);
+  font-weight: 500;
+}
+
+.session-item__duration {
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.session-item__time {
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+  min-width: 3.5rem;
+  text-align: right;
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,0 +1,27 @@
+// Base URL: set VITE_API_URL to override (e.g. production); defaults to '' for Vite proxy
+const BASE_URL = import.meta.env.VITE_API_URL ?? ''
+
+/**
+ * Fetch today's sessions from the backend.
+ * @returns {Promise<Array>}
+ */
+export async function getSessions() {
+  const res = await fetch(`${BASE_URL}/api/sessions`)
+  if (!res.ok) throw new Error(`GET /api/sessions failed: ${res.status}`)
+  return res.json()
+}
+
+/**
+ * Save a completed session to the backend.
+ * @param {{ type: string, duration: number, timestamp: string }} session
+ * @returns {Promise<Object>} saved session with generated id
+ */
+export async function postSession({ type, duration, timestamp }) {
+  const res = await fetch(`${BASE_URL}/api/sessions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ type, duration, timestamp }),
+  })
+  if (!res.ok) throw new Error(`POST /api/sessions failed: ${res.status}`)
+  return res.json()
+}


### PR DESCRIPTION
Feature #3 for Issue #1.

## What was implemented

### API Service (`src/services/api.js`)
- `getSessions()` — `GET /api/sessions`
- `postSession({ type, duration, timestamp })` — `POST /api/sessions`
- Base URL from `import.meta.env.VITE_API_URL` (defaults to `""` for Vite proxy)

### useSessions Hook (`src/hooks/useSessions.js`)
- Fetches sessions on mount via `useEffect`
- `saveSession(type, duration)` — POSTs with `timestamp: new Date().toISOString()`, then re-fetches
- Degrades gracefully when backend unavailable (no crash)

### SessionHistory Component (`src/components/SessionHistory.jsx`)
- Header: "Today's Sessions" + 🍅 N pomodoros count (work sessions only)
- List: reverse-chronological, each row shows icon / Work or Break / duration / time
- Loading and empty states

### App.jsx
- Imports and calls `useSessions`
- Passes `onComplete: (mode, duration) => saveSession(mode, duration)` to `useTimer`
- Renders `<SessionHistory>` below the timer card

## Acceptance criteria

- [x] History loads on app startup (GET /api/sessions on mount)
- [x] Completed sessions appear immediately after timer finishes (POST + re-fetch in onComplete)
- [x] Work pomodoro count increments correctly
- [x] List shows type (icon + label) and time for each session
- [x] `VITE_API_URL` env var supported; defaults to empty string (Vite proxy)
- [x] Build passes: `vite build` → 38 modules ✅

---
*Created by Antigravity Dev Agent*